### PR TITLE
Issue #5: CI failures already resolved in PR #2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: undefined
+Your prepared branch: issue-5-12cd00e7
+Your prepared working directory: /tmp/gh-issue-solver-1761373112439
+
+Proceed.


### PR DESCRIPTION
## Summary

This PR addresses issue #5, which reported failing tests from CI run [18516405920](https://github.com/link-foundation/test-anywhere/actions/runs/18516405920/job/52767499726).

## Investigation

After thorough investigation, I found that:

1. **Root Cause Identified**: The Deno tests were failing with the error:
   ```
   Error: Could not find a matching package for 'npm:@types/node' in the node_modules directory. 
   Ensure you have all your JSR and npm dependencies listed in your deno.json or package.json, 
   then run `deno install`. Alternatively, turn on auto-install by specifying 
   `"nodeModulesDir": "auto"` in your deno.json file.
   ```
   (See ci-logs/failed-run-18516405920.log:479)

2. **Fix Already Applied**: The failing run referenced in issue #5 was from PR #2 during development. The final merged version of PR #2 included the fix: adding `deno.json` with the configuration:
   ```json
   {
     "nodeModulesDir": "auto"
   }
   ```

3. **Current Status**: All CI checks are now passing:
   - ✅ Latest run on our branch (issue-5-12cd00e7): [18799324231](https://github.com/link-foundation/test-anywhere/actions/runs/18799324231) - All tests passing (Node.js, Bun, Deno)
   - ✅ Latest run on main: [18517880125](https://github.com/link-foundation/test-anywhere/actions/runs/18517880125) - All tests passing

## Conclusion

The issue reported in #5 has already been resolved. The `deno.json` configuration file was added in commit `a695a24` as part of PR #2, which fixed the Deno test failures. No additional changes are needed.

## Closes

Closes #5

---
*🤖 Generated with [Claude Code](https://claude.com/claude-code)*