### PR TITLE
Fix auto-merge workflow to recognize app/github-actions bot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/test-anywhere/issues/40
-Your prepared branch: issue-40-4490edd8e721
-Your prepared working directory: /tmp/gh-issue-solver-1762147300682
-
-Proceed.


### PR DESCRIPTION
## 📋 Issue Reference
Fixes #40

## 🔍 Problem Analysis

The auto-merge workflow for changesets version PRs was failing with the message:
> Skipping: not from github-actions bot

### Root Cause
The workflow was checking if the PR author matches the pattern `github-actions*`, but the actual author login for PRs created by GitHub Actions using the changesets action is `app/github-actions`, which doesn't match this pattern.

Evidence from the failed workflow run:
```
Found PR #39: chore: version packages (author: app/github-actions, draft: false)
  Skipping: not from github-actions bot
```

## ✅ Solution

Updated the bot detection logic in `.github/workflows/auto-merge-version-pr.yml` to accept either:
- Authors matching the `github-actions*` pattern (backward compatible)
- The specific `app/github-actions` login (the actual bot login used by changesets)

### Changes Made
Modified two locations in the workflow file:
1. Line 49: The `auto-merge` job's PR check step
2. Line 161: The `auto-merge-on-checks` job's version PR finder step

Both now use the condition:
```bash
if [[ "$PR_AUTHOR" != "github-actions"* && "$PR_AUTHOR" != "app/github-actions" ]]; then
```

## 🧪 Testing
- Verified the PR author for #39 is indeed `app/github-actions`
- Reviewed workflow logs to confirm the exact failure point
- The fix maintains backward compatibility with other possible GitHub Actions bot login formats

## 📝 Additional Notes
This fix will allow the auto-merge workflow to properly recognize and process version PRs created by the changesets GitHub Action, enabling automatic merging when all CI checks pass.

---
*This PR was created automatically by the AI issue solver*