### PR TITLE
fix: proper PR detection via commit hash lookup

### DIFF
--- a/.changeset/manual-release-955174a7.md
+++ b/.changeset/manual-release-955174a7.md
@@ -2,4 +2,4 @@
 'test-anywhere': patch
 ---
 
-Fix PR detection for instant releases - skip PR detection when triggered via workflow_dispatch to avoid incorrectly linking to unrelated PRs
+Fix PR detection in release notes - properly look up PRs by commit hash via GitHub API instead of using fallback guessing. If no PR contains the commit, no PR link is shown.

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -199,12 +199,9 @@ jobs:
 
           if [ -n "$RELEASE_ID" ]; then
             echo "Formatting release notes for $TAG..."
-            # For instant releases (workflow_dispatch), skip PR detection since there is no associated PR
-            if [ "${{ inputs.release_mode }}" == "instant" ]; then
-              node scripts/format-release-notes.mjs "$RELEASE_ID" "$TAG" "${{ github.repository }}" --skip-pr-detection
-            else
-              node scripts/format-release-notes.mjs "$RELEASE_ID" "$TAG" "${{ github.repository }}"
-            fi
+            # Pass the trigger commit SHA for PR detection
+            # This allows proper PR lookup even if the changelog doesn't have a commit hash
+            node scripts/format-release-notes.mjs "$RELEASE_ID" "$TAG" "${{ github.repository }}" --commit-sha=${{ github.sha }}
             echo "✅ Formatted release notes for $TAG"
           else
             echo "⚠️ Could not find release for $TAG"


### PR DESCRIPTION
## Summary

Fixes #104 - Instant releases triggered via workflow_dispatch were incorrectly linking to unrelated PRs in the release notes.

### Root Cause

The `format-release-notes.mjs` script had a greedy fallback logic that searched for recent merged PRs with "manual" or "changeset" in the title when no commit hash was available. This caused instant releases (like v0.8.24) to incorrectly link to unrelated PRs (like #103) simply because they happened to be recently merged.

### Solution

Implement proper PR detection via commit hash lookup:

1. **Extract commit hash from changelog** (if present in format `- abc1234: Description`)
2. **Accept `--commit-sha=<sha>` argument** from workflow to pass the trigger commit
3. **Look up PRs via GitHub API**: `GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls`
4. **If no PR found, simply don't display any PR link** - no guessing or fallback

This ensures release notes only link to PRs that **actually contain** the release commit.

### Changes

1. **scripts/format-release-notes.mjs**:
   - Removed `--skip-pr-detection` workaround flag
   - Added `--commit-sha=<sha>` argument for workflow to pass trigger commit
   - Prioritizes changelog commit hash, falls back to passed commit SHA
   - Uses GitHub API `/commits/{sha}/pulls` for accurate PR lookup
   - Added clear log messages showing commit source (changelog vs workflow)
   - Removed greedy fallback search for recent merged PRs

2. **.github/workflows/common.yml**:
   - Removed conditional `--skip-pr-detection` flag for instant releases
   - Now always passes `--commit-sha=${{ github.sha }}` for PR detection

3. **experiments/test-skip-pr-detection.mjs**:
   - Updated test script to verify the new implementation

### How It Works Now

| Scenario | Commit Source | PR Found? | Result |
|----------|---------------|-----------|--------|
| Changeset release | Changelog hash | Yes | Shows PR link |
| Changeset release | Changelog hash | No | No PR link |
| Instant release | `github.sha` | Yes | Shows PR link |
| Instant release | `github.sha` | No | No PR link (correct!) |

For v0.8.24-style instant releases pushed directly to main, no PR contains that commit, so no PR link is shown - which is the correct behavior.

## Test plan

- [x] Updated test script to verify new implementation
- [x] All 10 tests pass locally
- [x] Run local lint and format checks
- [x] Run local tests (`npm test`)
- [ ] Wait for CI to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)